### PR TITLE
Added modules

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,2 @@
+from normalizing_flow import *
+from encoder import *

--- a/modules/encoder.py
+++ b/modules/encoder.py
@@ -1,0 +1,86 @@
+"""Networks that can be used as encoders in a variational autoencoder."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.rnn_utils import pack_padded_sequence
+
+
+def RNNTextEncoder(nn.Module):
+    """Recurrent neural network for encoding text.
+
+    Args:
+        dim: Dimension of the latent variable.
+        vocab_size: Number of words in the vocabulary.
+        embedding_size: Size of word embedding vectors.
+        hidden_size: Number of hidden units in each recurrent layer.
+        bidirectional: If `True` becomes a bidirectional RNN.
+        dropout_rate: Probability of a word being droped out.
+    """
+    # TODO: Allow for multiple layers.
+    def __init__(self,
+                 dim,
+                 vocab_size,
+                 embedding_size,
+                 hidden_size,
+                 bidirectional=False,
+                 dropout_rate=0.0):
+        super(RNNTextEncoder, self).__init__()
+
+        self.dim = dim
+        self.vocab_size = vocab_size
+        self.embedding_size = embedding_size
+        self.bidirectional = bidirectional
+        self.num_directions = (2 if bidirectional else 1)
+        self.dropout_rate = dropout_rate
+
+        self.embedding = nn.Embedding(vocab_size, embedding_size)
+        self.word_dropout = nn.Dropout(dropout_rate)
+        self.rnn_encoder = nn.GRU(embedding_size, hidden_size,
+                                  num_layers=1,
+                                  bidirectional=bidirectional,
+                                  batch_first=True)
+        self.hidden2mean = nn.Linear(hidden_size * num_directions, dim)
+        self.hidden2logv = nn.Linear(hidden_size * num_directions, dim)
+
+    def forward(self, x, lengths):
+        """Computes forward pass of the text encoder.
+
+        Args:
+            x: torch.Tensor(batch_size, seq_len). Input data.
+            lengths: List of sequence lengths of each batch element.
+
+        Returns:
+            mu: torch.Tensor(batch_size, dim).
+            sigma: torch.Tensor(batch_size, dim).
+        """
+        # Stupid torch sequence sorting -_-
+        batch_size = x.shape[0]
+        sorted_lengths, sorted_idx = torch.sort(lengths, descending=True)
+        _, unsorted_idx = torch.sort(sorted_idx)
+        x = x[sorted_idx]
+
+        # Embed
+        embeddings = self.embedding(x)
+
+        # Feed through RNN
+        packed = pack_padded_sequence(embeddings, lengths, batch_first=True)
+        _, hidden = self.rnn_encoder(packed)
+
+        # Flatten hidden
+        if self.num_directions > 1 or self.num_layers > 1:
+            hidden = hidden.view(batch_size, self.hidden_size * self.num_directions)
+        else:
+            hidden.squeeze_()
+
+        # FC layer
+        mean = self.hidden2mean(hidden)
+        logv = self.hidden2logv(hidden)
+        std = torch.exp(0.5 * logv)
+
+        # Stupid torch sequence unsorting -_-
+        mean = mean[unsorted_idx]
+        std = std[unsorted_idx]
+
+        return mu, sigma
+

--- a/modules/normalizing_flow.py
+++ b/modules/normalizing_flow.py
@@ -1,0 +1,140 @@
+"""Implementation of normalizing flows, initially described in:
+
+    'Variational Inference with Normalizing Flows'
+    Rezende and Mohamed, ICML 2015
+
+"""
+from math import sqrt
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class NormalizingFlow(nn.Module):
+    """General implementation of a normalizing flow.
+
+    Normalizing flows apply a series of maps to a latent variable.
+
+    NOTE: Keyword arguments are passed to the maps.
+
+    Args:
+        dim: Dimension of the latent variable.
+        map: Type of map applied at each step of the flow. Should be a subclass
+            of the `Map` object.
+        K: Number of maps to apply.
+    """
+    def __init__(self, dim, map, K, **kwargs):
+        super(NormalizingFlow, self).__init__()
+
+        self.dim = dim
+        self.K = K
+
+        self.maps = nn.ModuleList([map(dim, **kwargs) for _ in range(K)])
+
+    def forward(self, z):
+        """Computes forward pass of the planar flow.
+
+        Args:
+            z: torch.Tensor(batch_size, dim).
+                The latent variable.
+
+        Returns:
+            f_z: torch.Tensor(batch_size, dim).
+                The output of the final map
+            sum_logdet: scalar.
+                The sum of the log-determinants of the transformations.
+        """
+        f_z = z
+        sum_logdet = 0.0
+        for planar_map in self.planar_maps:
+            f_z, logdet = planar_map(f_z)
+            sum_logdet += logdet
+        return f_z, sum_logdet
+
+
+class Map(nn.Module):
+    """Generic parent class for maps used in a normalizing flow.
+
+    Args:
+        dim: Dimensionality of the latent variable.
+    """
+    def __init__(self, dim):
+        super(Map, self).__init__()
+
+    def forward(self, z):
+        """Computes the forward pass of the map.
+
+        This method should be implemented for each subclass of Map. This
+        function should always have the following signature:
+
+        Args:
+            z: torch.Tensor(batch_size, dim).
+                The latent variable.
+
+        Returns:
+            f_z: torch.Tensor(batch_size, dim).
+                The transformed latent variable.
+            logdet: scalar.
+                The log-determinant of the transformation.
+        """
+        raise NotImplementedError
+
+
+class PlanarMap(Map):
+    """The map used in planar flows, as described in:
+
+        'Variational Inference with Normalizing Flows'
+            Rezende and Mohamed, ICML 2015
+
+    Args:
+        dim: Dimensionality of the latent variable.
+    """
+    def __init__(self, dim):
+        super(PlanarMap, self).__init__(dim)
+
+        self.u = torch.nn.Parameter(torch.Tensor(1, dim))
+        self.w = torch.nn.Parameter(torch.Tensor(1, dim))
+        self.b = torch.nn.Parameter(torch.Tensor(1))
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Resets planar map parameters."""
+        a = sqrt(6 / self.dim)
+
+        self.u.data.uniform_(-a, a)
+        self.w.data.uniform_(-a, a)
+        self.b.data.uniform_(-a, a)
+
+    def forward(self, z):
+        """Computes forward pass of the planar map.
+
+        Args:
+            z: torch.Tensor(batch_size, dim).
+                The latent variable.
+
+        Returns:
+            f_z: torch.Tensor(batch_size, dim).
+                The transformed latent variable.
+            logdet: scalar.
+                The log-determinant of the transformation.
+        """
+        # Ensure invertibility using approach in appendix A.1
+        wu = torch.matmul(self.u, self.w.t()).squeeze()
+        mwu = F.softplus(wu) - 1
+        u_hat = self.u + (mwu - wu) * self.w / torch.sum(self.w**2)
+
+        # Compute f_z using Equation 10.
+        wz = torch.matmul(self.w, z.unsqueeze(2))
+        wz.squeeze_(2)
+        f_z = z + self.u * F.tanh(wz + self.b)
+
+        # Compute psi using Equation 11.
+        psi = self.w * (1 - F.tanh(wz + self.b)**2)
+
+        # Compute logdet using Equation 12.
+        logdet = torch.log(torch.abs(1 + torch.matmul(self.u, psi.t())))
+
+        return f_z, logdet
+


### PR DESCRIPTION
Added a `modules` folder, which will contain the different components of our normalizing flow VAEs.

Nothing in this commit breaks the existing code since it isn't incorporated yet. I just wanted to give a preview of the structure I am adopting, specifically the `modules/normalizing_flow.py` module.

The idea is that the ResNet and Linear IAF transformations should be implemented as subclasses of the `Map` class. See the code for more details.